### PR TITLE
Terminix was renamed to Tilix. 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -131,8 +131,8 @@ NORD_TERMINIX_SCRIPT_OPTS=`getopt -o vghs: --long verbose,global,help,schemefile
 COLOR_SCHEME_FILE=src/json/nord.json
 VERBOSE=false
 GLOBAL_INSTALL=false
-LOCAL_INSTALL_DIR=~/.config/terminix/schemes
-GLOBAL_INSTALL_DIR=/usr/share/terminix/schemes
+LOCAL_INSTALL_DIR=~/.config/tilix/schemes
+GLOBAL_INSTALL_DIR=/usr/share/tilix/schemes
 
 eval set -- "$NORD_TERMINIX_SCRIPT_OPTS"
 while true; do


### PR DESCRIPTION
Terminix was renamed to Tilix because of legal issues.
Changed the Directories to the new tilix directories. 
Maybe nord-terminix should be renamed to nord-tilix as well.
See: https://github.com/gnunn1/tilix